### PR TITLE
Add docstrings to top-level scripts

### DIFF
--- a/args_manager.py
+++ b/args_manager.py
@@ -1,3 +1,5 @@
+"""Command line argument setup for DeFooocus."""
+
 import ldm_patched.modules.args_parser as args_parser
 import os
 

--- a/build_launcher.py
+++ b/build_launcher.py
@@ -1,3 +1,5 @@
+"""Utility for generating Windows launcher batch files."""
+
 import os
 
 win32_root = os.path.dirname(os.path.dirname(__file__))
@@ -12,6 +14,7 @@ pause
 
 
 def build_launcher():
+    """Create Windows batch launchers for different presets."""
     if not is_win32_standalone_build:
         return
 

--- a/entry_with_update.py
+++ b/entry_with_update.py
@@ -1,3 +1,5 @@
+"""Self-updating entry point that fetches Git updates before launching."""
+
 import os
 import sys
 

--- a/experiments_expansion.py
+++ b/experiments_expansion.py
@@ -1,3 +1,5 @@
+"""Simple test script for the Fooocus text expansion module."""
+
 from modules.expansion import FooocusExpansion
 
 expansion = FooocusExpansion()

--- a/experiments_face.py
+++ b/experiments_face.py
@@ -1,3 +1,5 @@
+"""Demonstration script for the face cropping utility."""
+
 import cv2
 import extras.face_crop as cropper
 

--- a/experiments_interrogate.py
+++ b/experiments_interrogate.py
@@ -1,3 +1,5 @@
+"""Example usage of the photo and anime interrogators."""
+
 import cv2
 from extras.interrogate import default_interrogator as default_interrogator_photo
 from extras.wd14tagger import default_interrogator as default_interrogator_anime

--- a/fooocus_version.py
+++ b/fooocus_version.py
@@ -1,1 +1,3 @@
+"""Application version information."""
+
 version = '0.2'

--- a/launch.py
+++ b/launch.py
@@ -1,3 +1,5 @@
+"""Launches the DeFooocus application after preparing the environment."""
+
 import os
 import sys
 import ssl
@@ -28,6 +30,7 @@ TRY_INSTALL_XFORMERS = False
 
 
 def prepare_environment():
+    """Install dependencies and prepare environment variables."""
     torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu121")
     torch_command = os.environ.get('TORCH_COMMAND',
                                    f"pip install torch==2.1.0 torchvision==0.16.0 --extra-index-url {torch_index_url}")
@@ -69,6 +72,7 @@ vae_approx_filenames = [
 
 
 def ini_args():
+    """Import and return command line arguments."""
     from args_manager import args
     return args
 
@@ -86,6 +90,7 @@ os.environ["U2NET_HOME"] = config.path_inpaint
 
 
 def download_models(default_model, previous_default_models, checkpoint_downloads, embeddings_downloads, lora_downloads):
+    """Download model files required for operation."""
     for file_name, url in vae_approx_filenames:
         load_file_from_url(url=url, model_dir=config.path_vae_approx, file_name=file_name)
 

--- a/shared.py
+++ b/shared.py
@@ -1,1 +1,3 @@
+"""Shared state used across modules."""
+
 gradio_root = None

--- a/webui.py
+++ b/webui.py
@@ -1,3 +1,5 @@
+"""Gradio-based user interface for DeFooocus."""
+
 import gradio as gr
 import random
 import os
@@ -33,16 +35,19 @@ PHOTOPEA_IFRAME_LOADED_EVENT = "onPhotopeaLoaded"
 
 
 def get_photopea_url_params():
-    return "#%7B%22resources%22:%5B%22data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAIAAQMAAADOtka5AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAANQTFRF////p8QbyAAAADZJREFUeJztwQEBAAAAgiD/r25IQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfBuCAAAB0niJ8AAAAABJRU5ErkJggg==%22%5D%7D"
+    """Return URL parameters for loading Photopea with a blank canvas."""
+    return ("#%7B%22resources%22:%5B%22data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAIAAQMAAADOtka5AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAANQTFRF////p8QbyAAAADZJREFUeJztwQEBAAAAgiD/r25IQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfBuCAAAB0niJ8AAAAABJRU5ErkJggg==%22%5D%7D")
 
 
 def get_task(*args):
+    """Create an AsyncTask from UI parameters."""
     args = list(args)
     args.pop(0)
 
     return worker.AsyncTask(args=args)
 
 def generate_clicked(task):
+    """Handle the generation button click and stream progress."""
     import ldm_patched.modules.model_management as model_management
 
     with model_management.interrupt_processing_mutex:
@@ -860,6 +865,7 @@ with shared.gradio_root:
                        outputs=[prompt, style_selections], show_progress=True, queue=True)
 
 def dump_default_english_config():
+    """Dump the default English localization file."""
     from modules.localization import dump_english_config
     dump_english_config(grh.all_components)
 


### PR DESCRIPTION
## Summary
- document modules with brief docstrings
- describe functions in launch and webui

## Testing
- `python -m py_compile args_manager.py build_launcher.py entry_with_update.py experiments_expansion.py experiments_face.py experiments_interrogate.py fooocus_version.py launch.py shared.py webui.py`

------
https://chatgpt.com/codex/tasks/task_e_6840505c25b48329a60f2ef32ef45311